### PR TITLE
Accelerate image drawing

### DIFF
--- a/Software/Python/bakebit_128_64_oled.py
+++ b/Software/Python/bakebit_128_64_oled.py
@@ -191,6 +191,13 @@ def sendData(byte):
         print("IOError")
         return -1
 
+def sendArrayData(array):
+    try:
+        return bus.write_i2c_block_data(address,SeeedOLED_Data_Mode,array)
+    except IOError:
+        print("IOError")
+        return -1    
+
 def multi_comm(commands):
     for c in commands:
         sendCommand(c)
@@ -355,19 +362,26 @@ def drawImage(image):
     # Grab all the pixels from the image, faster than getpixel.
     pix = image.load()
     # Iterate through the memory pages
-    index = 0
+    bitList = []
     pages=SeeedOLED_Height/8
     for page in range(pages):
-       # Iterate through all x axis columns.
+        # Iterate through all x axis columns.
         for x in range(SeeedOLED_Width):
-           # Set the bits for the column of pixels at the current position.
+            # Set the bits for the column of pixels at the current position.
             bits = 0
             # Don't use range here as it's a bit slow
             for bit in [0, 1, 2, 3, 4, 5, 6, 7]:
                 bits = bits << 1
-                bits |= 0 if pix[(x, page*8+7-bit)] == 0 else 1
-	    sendData(bits)
-            index += 1
+                bits |= 0 if pix[x, page*8+7-bit] == 0 else 1
+            bitList.append(bits)
+
+    for chunk in chunks(bitList, 32):
+        sendArrayData(chunk)
+
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
 		
 def putNumber(long_num):
 	char_buffer[10]=None


### PR DESCRIPTION
Sending 32 bytes instead of single bytes to the display. This speeds up the draw call significantly.